### PR TITLE
Fix parse error message always display

### DIFF
--- a/templates/feeds.php
+++ b/templates/feeds.php
@@ -49,11 +49,11 @@
                             <?= t('never updated after creation') ?>
                         </span>
                     <?php endif ?>
-
+                    <?php if ($feed['parsing_error']): ?>
                     <span class="feed-parsing-error">
                             <?= t('(error occurred during the last check)') ?>
                     </span>
-
+                    <?php endif ?>
                 <?php endif ?>
             </h2>
             <ul class="item-menu">


### PR DESCRIPTION
The " (error occurred during the last check) " message was always display when refreshing the flux if no new feed (at least on the "boostrap light" skin). So adding a condition to display the message only if there is really a parse error.
